### PR TITLE
2.7.0 compatability updates

### DIFF
--- a/cdap-etl-pack/cdap-etl-pack-api/src/main/java/co/cask/cdap/packs/etl/Constants.java
+++ b/cdap-etl-pack/cdap-etl-pack-api/src/main/java/co/cask/cdap/packs/etl/Constants.java
@@ -32,7 +32,7 @@ public final class Constants  {
   public static final String ARG_TASK_ID = "etl.taskId";
 
   /** Name of the stream to be used by flow upon deploying an app. Actual stream source is set after deploy */
-  public static final String DEFAULT_INPUT_STREAM = "default-stream";
+  public static final String DEFAULT_INPUT_STREAM = "default_stream";
 
   /** Batch processing configuration option names */
   public static final class Batch {

--- a/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/BatchETL.java
+++ b/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/BatchETL.java
@@ -52,7 +52,7 @@ public class BatchETL extends DatasetsTrackingApplication {
 
     long intervalInMinutes = 10;
     String cronEntry = "0/" + intervalInMinutes + " * * * *";
-    scheduleWorkflow("FiveMinuteSchedule", cronEntry, ETLMapReduceWorkflow.NAME);
+    scheduleWorkflow("TenMinuteSchedule", cronEntry, ETLMapReduceWorkflow.NAME);
   }
 
   protected void configure(Configurer configurer) {

--- a/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/BatchETL.java
+++ b/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/BatchETL.java
@@ -48,7 +48,11 @@ public class BatchETL extends DatasetsTrackingApplication {
 
     // todo: this seems redundant: we add it as part of workflow
     addMapReduce(mapReduce);
-    addWorkflow(new ETLMapReduceWorkflow(mapReduce));
+    addWorkflow(new ETLMapReduceWorkflow(ETLMapReduce.NAME));
+
+    long intervalInMinutes = 10;
+    String cronEntry = "0/" + intervalInMinutes + " * * * *";
+    scheduleWorkflow("FiveMinuteSchedule", cronEntry, ETLMapReduceWorkflow.NAME);
   }
 
   protected void configure(Configurer configurer) {

--- a/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/ETLMapReduce.java
+++ b/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/ETLMapReduce.java
@@ -43,6 +43,7 @@ import java.util.Set;
  * Map-reduce program that performs ETL work
  */
 public class ETLMapReduce extends AbstractMapReduce {
+  public static final String NAME = "ETLMapReduce";
   // Optional: will be resolved via args
   private MapReduceSource source = null;
   private Transformation transformation = null;
@@ -76,7 +77,7 @@ public class ETLMapReduce extends AbstractMapReduce {
       args.putAll(sink.getConfiguration());
     }
 
-    setName("ETLMapReduce");
+    setName(NAME);
     setDescription("");
     setProperties(args);
     useDatasets(ImmutableList.of(Constants.DICTIONARY_DATASET, Constants.ETL_META_DATASET));

--- a/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/ETLMapReduceWorkflow.java
+++ b/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/ETLMapReduceWorkflow.java
@@ -16,32 +16,23 @@
 
 package co.cask.cdap.packs.etl.batch;
 
-import co.cask.cdap.api.mapreduce.MapReduce;
-import co.cask.cdap.api.schedule.Schedule;
-import co.cask.cdap.api.workflow.Workflow;
-import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
 
 /**
- * Schedules MapReduce ETL job
+ * Contains MapReduce ETL job
  */
-public class ETLMapReduceWorkflow implements Workflow {
+public class ETLMapReduceWorkflow extends AbstractWorkflow {
+  public static final String NAME = "ETLMapReduceWorkFlow";
+  private String mapReduce = null;
 
-  private MapReduce mapReduce = null;
-
-  public ETLMapReduceWorkflow(MapReduce mapReduce) {
+  public ETLMapReduceWorkflow(String mapReduce) {
     this.mapReduce = mapReduce;
   }
 
   @Override
-  public WorkflowSpecification configure() {
-    long intervalInMinutes = 10;
-    return WorkflowSpecification.Builder.with()
-      .setName("ETLMapReduceWorkflow")
-      .setDescription("Performs incremental processing with MapReduce job")
-      .onlyWith(mapReduce == null ? new ETLMapReduce() : mapReduce)
-      .addSchedule(new Schedule(
-        "FiveMinuteSchedule", "Run every " + intervalInMinutes + " minutes",
-        "0/" + intervalInMinutes + " * * * *", Schedule.Action.START))
-      .build();
+  public void configure() {
+    setName(NAME);
+    setDescription("Performs incremental processing with MapReduce job");
+    addMapReduce(mapReduce);
   }
 }

--- a/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/ETLMapReduceWorkflow.java
+++ b/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/ETLMapReduceWorkflow.java
@@ -19,7 +19,7 @@ package co.cask.cdap.packs.etl.batch;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
 
 /**
- * Contains MapReduce ETL job
+ * Contains ETL MapReduce program
  */
 public class ETLMapReduceWorkflow extends AbstractWorkflow {
   public static final String NAME = "ETLMapReduceWorkFlow";
@@ -32,7 +32,7 @@ public class ETLMapReduceWorkflow extends AbstractWorkflow {
   @Override
   public void configure() {
     setName(NAME);
-    setDescription("Performs incremental processing with MapReduce job");
+    setDescription("Performs incremental processing with ETL MapReduce");
     addMapReduce(mapReduce);
   }
 }

--- a/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/source/StreamSource.java
+++ b/cdap-etl-pack/cdap-etl-pack-core/src/main/java/co/cask/cdap/packs/etl/batch/source/StreamSource.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.packs.etl.batch.source;
 
+import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.packs.etl.Constants;
 import co.cask.cdap.packs.etl.Programs;
@@ -33,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -113,7 +115,7 @@ public class StreamSource extends SchemaSource<LongWritable, Text> {
 
     String inputStreamUri = String.format("stream://%s?start=%d&end=%d", inputStream, startTime, endTime);
     LOG.info("Set input to {}", inputStreamUri);
-    context.setInput(inputStreamUri, null);
+    context.setInput(inputStreamUri, (List<Split>) null);
   }
 
   @Override

--- a/cdap-etl-pack/cdap-etl-pack-hbase/src/main/java/co/cask/cdap/packs/etl/batch/sink/HBaseSink.java
+++ b/cdap-etl-pack/cdap-etl-pack-hbase/src/main/java/co/cask/cdap/packs/etl/batch/sink/HBaseSink.java
@@ -122,6 +122,8 @@ public class HBaseSink extends AbstractConfigurableProgram<MapReduceContext> imp
 
   private void createTableIfNotExists(String tableName, String zkQuorum, int zkClientPort) throws IOException {
     Configuration conf = HBaseConfiguration.create();
+    // https://github.com/apache/hbase/pull/10
+    conf.setClassLoader(HBaseConfiguration.class.getClassLoader());
     conf.set(HConstants.ZOOKEEPER_QUORUM, zkQuorum);
     conf.setInt(HConstants.ZOOKEEPER_CLIENT_PORT, zkClientPort);
     conf.set(HConstants.ZOOKEEPER_ZNODE_PARENT, zkParentNode);

--- a/cdap-etl-pack/cdap-etl-pack-hbase/src/main/java/co/cask/cdap/packs/etl/realtime/sink/HBaseSink.java
+++ b/cdap-etl-pack/cdap-etl-pack-hbase/src/main/java/co/cask/cdap/packs/etl/realtime/sink/HBaseSink.java
@@ -101,6 +101,8 @@ public class HBaseSink extends AbstractConfigurableProgram<FlowletContext> imple
     zkParentNode = Programs.getRequiredArgOrProperty(context, Constants.Realtime.Sink.HBase.ARG_HBASE_ZOOKEEPER_PARENT_NODE);
 
     Configuration conf = HBaseConfiguration.create();
+    // https://github.com/apache/hbase/pull/10
+    conf.setClassLoader(HBaseConfiguration.class.getClassLoader());
     conf.set(HConstants.ZOOKEEPER_QUORUM, zkQuorum);
     conf.setInt(HConstants.ZOOKEEPER_CLIENT_PORT, zkClientPort);
     conf.set(HConstants.ZOOKEEPER_ZNODE_PARENT, zkParentNode);

--- a/cdap-etl-pack/cdap-etl-pack-hbase/src/test/java/co/cask/cdap/packs/etl/realtime/sink/HBaseSinkTest.java
+++ b/cdap-etl-pack/cdap-etl-pack-hbase/src/test/java/co/cask/cdap/packs/etl/realtime/sink/HBaseSinkTest.java
@@ -18,15 +18,15 @@ package co.cask.cdap.packs.etl.realtime.sink;
 
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.packs.etl.Constants;
+import co.cask.cdap.packs.etl.hbase.HBase96Test;
+import co.cask.cdap.packs.etl.hbase.HBaseTestBase;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.RuntimeMetrics;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.StreamWriter;
 import co.cask.cdap.test.TestBase;
-import co.cask.cdap.packs.etl.Constants;
-import co.cask.cdap.packs.etl.hbase.HBase96Test;
-import co.cask.cdap.packs.etl.hbase.HBaseTestBase;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import org.apache.hadoop.hbase.client.Get;

--- a/cdap-twitter-pack/src/test/java/co/cask/cdap/packs/twitter/TweetCollectorApp.java
+++ b/cdap-twitter-pack/src/test/java/co/cask/cdap/packs/twitter/TweetCollectorApp.java
@@ -19,12 +19,12 @@ package co.cask.cdap.packs.twitter;
 import co.cask.cdap.api.annotation.ProcessInput;
 import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.dataset.lib.ObjectStore;
 import co.cask.cdap.api.dataset.lib.ObjectStores;
 import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
-import co.cask.cdap.internal.io.UnsupportedTypeException;
 
 import java.util.UUID;
 


### PR DESCRIPTION
Split into 3 commits:
- Update based upon workflow API change, and streams can no longer have dashes in the name.
- Twitter Pack required only a minor import change
- Fix a failing test case (HBaseSinkTest.java), due to classloading changes in CDAP.

Note that this relies on: https://github.com/caskdata/cdap/pull/1175 (also based upon the classloading change in CDAP).