### PR TITLE
Bump up version to 1.8.0-SNAPSHOT.

### DIFF
--- a/cdap-etl-pack/cdap-etl-pack-api/pom.xml
+++ b/cdap-etl-pack/cdap-etl-pack-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap.packs</groupId>
     <artifactId>cdap-etl-pack</artifactId>
-    <version>${cdap.etl.pack.version}</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-pack-api</artifactId>

--- a/cdap-etl-pack/cdap-etl-pack-app/pom.xml
+++ b/cdap-etl-pack/cdap-etl-pack-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap.packs</groupId>
     <artifactId>cdap-etl-pack</artifactId>
-    <version>${cdap.etl.pack.version}</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-pack-app</artifactId>

--- a/cdap-etl-pack/cdap-etl-pack-core/pom.xml
+++ b/cdap-etl-pack/cdap-etl-pack-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap.packs</groupId>
     <artifactId>cdap-etl-pack</artifactId>
-    <version>${cdap.etl.pack.version}</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-pack-core</artifactId>

--- a/cdap-etl-pack/cdap-etl-pack-hbase/pom.xml
+++ b/cdap-etl-pack/cdap-etl-pack-hbase/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap.packs</groupId>
     <artifactId>cdap-etl-pack</artifactId>
-    <version>${cdap.etl.pack.version}</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-pack-hbase</artifactId>

--- a/cdap-etl-pack/cdap-etl-pack-hive/pom.xml
+++ b/cdap-etl-pack/cdap-etl-pack-hive/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap.packs</groupId>
     <artifactId>cdap-etl-pack</artifactId>
-    <version>${cdap.etl.pack.version}</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-pack-hive</artifactId>

--- a/cdap-etl-pack/cdap-etl-pack-kafka/pom.xml
+++ b/cdap-etl-pack/cdap-etl-pack-kafka/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap.packs</groupId>
     <artifactId>cdap-etl-pack</artifactId>
-    <version>${cdap.etl.pack.version}</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-pack-kafka</artifactId>

--- a/cdap-etl-pack/pom.xml
+++ b/cdap-etl-pack/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>co.cask.cdap.packs</groupId>
   <artifactId>cdap-etl-pack</artifactId>
-  <version>${cdap.etl.pack.version}</version>
+  <version>1.8.0-SNAPSHOT</version>
   <name>CDAP ETL Pack</name>
   <description>
     CDAP ETL Pack is a core for building simple ETL pipelines and as well as collection of different sources,
@@ -39,7 +39,6 @@
   </modules>
 
   <properties>
-    <cdap.etl.pack.version>1.7.0-SNAPSHOT</cdap.etl.pack.version>
     <cdap.version>3.2.0-SNAPSHOT</cdap.version>
     <hadoop.version>2.3.0</hadoop.version>
     <hive.version>0.13.0</hive.version>


### PR DESCRIPTION
Note: This has not been compiling against CDAP 3.2.0-SNAPSHOT for a while. Reported https://issues.cask.co/browse/CDAP-3671 for that.