### PR TITLE
CDAP-3822 Exclude cdap-spark-core, to exclude CDAP's scala version.

### DIFF
--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/src/test/java/co/cask/cdap/kafka/flow/Kafka07ConsumerFlowletTest.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/src/test/java/co/cask/cdap/kafka/flow/Kafka07ConsumerFlowletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,8 +35,6 @@ import java.util.Properties;
 /**
  * Unit-test for Kafka consuming flowlet for Kafka 0.7.
  */
-// https://issues.cask.co/browse/CDAP-3822
-@Ignore
 public class Kafka07ConsumerFlowletTest extends KafkaConsumerFlowletTestBase {
 
   private static ZKClientService zkClient;

--- a/cdap-kafka-pack/cdap-kafka-flow/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014-2015 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -229,6 +229,10 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>co.cask.cdap</groupId>
+            <artifactId>cdap-spark-core</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3822
http://builds.cask.co/browse/CP-BD8-JOB1

Note that the bamboo build will fail until https://github.com/caskdata/cdap/pull/6731 gets merged and the snapshot JARs get deployed.