### PR TITLE
Bump twill version to 0.8.0-SNAPSHOT

### DIFF
--- a/cdap-kafka-pack/cdap-kafka-flow/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/pom.xml
@@ -61,6 +61,10 @@
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
+    <repository>
+      <id>snapshot</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </repository>
   </repositories>
 
 
@@ -93,7 +97,7 @@
     <kafka.version>0.8.1.1</kafka.version>
     <logback.version>1.1.2</logback.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <twill.version>0.6.0-incubating</twill.version>
+    <twill.version>0.8.0-SNAPSHOT</twill.version>
     <zkclient.version>0.3</zkclient.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>


### PR DESCRIPTION
Bump twill version to 0.8.0-SNAPSHOT, to be consistent with the twill version CDAP depends on.