### PR TITLE
Bump version to CDAP 4.0.0

### DIFF
--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>co.cask.cdap</groupId>
   <artifactId>cdap-kafka-flow</artifactId>
-  <version>0.11.0-SNAPSHOT</version>
+  <version>0.13.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>CDAP Kafka Flow Pack</name>
   <description>Data Application Platform for Hadoop: Kafka Flow Pack</description>
@@ -90,7 +90,7 @@
   </modules>
 
   <properties>
-    <cdap.version>3.6.0-SNAPSHOT</cdap.version>
+    <cdap.version>4.0.0-SNAPSHOT</cdap.version>
     <guava.version>13.0.1</guava.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.11</junit.version>

--- a/cdap-twitter-pack/pom.xml
+++ b/cdap-twitter-pack/pom.xml
@@ -23,13 +23,13 @@
   <artifactId>cdap-twitter-pack</artifactId>
   <groupId>co.cask.cdap.packs</groupId>
   <name>CDAP Twitter Pack</name>
-  <version>0.1.10-SNAPSHOT</version>
+  <version>0.1.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Data Application Platform for Hadoop: Twitter Pack</description>
   <url>https://github.com/caskdata/cdap-packs</url>
 
   <properties>
-    <cdap.version>3.6.0-SNAPSHOT</cdap.version>
+    <cdap.version>4.0.0-SNAPSHOT</cdap.version>
     <guava.version>13.0.1</guava.version>
     <twitter4j.version>[4.0,)</twitter4j.version>
     <slf4j.version>1.7.5</slf4j.version>


### PR DESCRIPTION
Versions are bumped by 2 since it was not done previously for 3.6.0-SNAPSHOT. So I have made that change in release/cdap-3.6-compatible branch and bumped the version by 2 in this PR for develop.