### PR TITLE
Revert version bump for release 3.6 and just drop snapshot

### DIFF
--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.12.0</version>
+    <version>0.11.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.12.0</version>
+    <version>0.11.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.12.0</version>
+    <version>0.11.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>co.cask.cdap</groupId>
   <artifactId>cdap-kafka-flow</artifactId>
-  <version>0.12.0</version>
+  <version>0.11.0</version>
   <packaging>pom</packaging>
   <name>CDAP Kafka Flow Pack</name>
   <description>Data Application Platform for Hadoop: Kafka Flow Pack</description>

--- a/cdap-twitter-pack/pom.xml
+++ b/cdap-twitter-pack/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>cdap-twitter-pack</artifactId>
   <groupId>co.cask.cdap.packs</groupId>
   <name>CDAP Twitter Pack</name>
-  <version>0.1.11</version>
+  <version>0.1.10</version>
   <packaging>jar</packaging>
   <description>Data Application Platform for Hadoop: Twitter Pack</description>
   <url>https://github.com/caskdata/cdap-packs</url>


### PR DESCRIPTION
Reverts the version bump done in this commit: https://github.com/caskdata/cdap-packs/commit/b25c6eb6e8e4e07656f43d02e29a761a239062ed

