### PR TITLE
revert down version from 0.13.0-SNAPSHOT to 0.12.0-SNAPSHOT

### DIFF
--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.13.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.13.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-kafka-flow</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.13.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka-pack/cdap-kafka-flow/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>co.cask.cdap</groupId>
   <artifactId>cdap-kafka-flow</artifactId>
-  <version>0.13.0-SNAPSHOT</version>
+  <version>0.12.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>CDAP Kafka Flow Pack</name>
   <description>Data Application Platform for Hadoop: Kafka Flow Pack</description>

--- a/cdap-twitter-pack/pom.xml
+++ b/cdap-twitter-pack/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>cdap-twitter-pack</artifactId>
   <groupId>co.cask.cdap.packs</groupId>
   <name>CDAP Twitter Pack</name>
-  <version>0.1.12-SNAPSHOT</version>
+  <version>0.1.11-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Data Application Platform for Hadoop: Twitter Pack</description>
   <url>https://github.com/caskdata/cdap-packs</url>


### PR DESCRIPTION
Brings down the version to one lower which was bumped to two level higher in https://github.com/caskdata/cdap-packs/pull/74

