### PR TITLE
(CDAP-7826) Bump twill version

### DIFF
--- a/cdap-kafka-pack/cdap-kafka-flow/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/pom.xml
@@ -97,7 +97,7 @@
     <kafka.version>0.8.1.1</kafka.version>
     <logback.version>1.1.2</logback.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <twill.version>0.8.0</twill.version>
+    <twill.version>0.9.0-SNAPSHOT</twill.version>
     <zkclient.version>0.3</zkclient.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-7826
There is some change in twill which causes the navigator test to fail, need to bump the twill version since navigator has a dependency on the kafka-compat.