### PR TITLE
CDAP-7731 Add limits on number of messages and duration to process per flowlet tick method

### DIFF
--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/src/test/java/co/cask/cdap/kafka/flow/Kafka07ConsumingApp.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.7/src/test/java/co/cask/cdap/kafka/flow/Kafka07ConsumingApp.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Application for testing Kafka consuming flowlet for Kafka 0.7.
@@ -72,6 +73,9 @@ public class Kafka07ConsumingApp extends KafkaConsumingApp {
           throw new IllegalStateException("Failed with value: " + value);
         }
         return;
+      } else if (value.startsWith("sleep")) {
+        // 'sleep:500'
+        TimeUnit.MILLISECONDS.sleep(Integer.parseInt(value.split(":")[1]));
       }
       emitter.emit(value);
     }
@@ -85,6 +89,12 @@ public class Kafka07ConsumingApp extends KafkaConsumingApp {
         configurer.setBrokers(runtimeArgs.get("kafka.brokers"));
       }
       setupTopicPartitions(configurer, runtimeArgs);
+      if (runtimeArgs.containsKey("batch.size")) {
+        configurer.setProcessBatchSize(Integer.parseInt(runtimeArgs.get("batch.size")));
+      }
+      if (runtimeArgs.containsKey("max.process.millis")) {
+        configurer.setMaxProcessTime(Integer.parseInt(runtimeArgs.get("max.process.millis")));
+      }
     }
 
     @Override

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/src/test/java/co/cask/cdap/kafka/flow/Kafka08ConsumingApp.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-compat-0.8/src/test/java/co/cask/cdap/kafka/flow/Kafka08ConsumingApp.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Application for testing Kafka consuming flowlet for Kafka 0.8.
@@ -72,6 +73,9 @@ public class Kafka08ConsumingApp extends KafkaConsumingApp {
           throw new IllegalStateException("Failed with value: " + value);
         }
         return;
+      } else if (value.startsWith("sleep")) {
+        // 'sleep:500'
+        TimeUnit.MILLISECONDS.sleep(Integer.parseInt(value.split(":")[1]));
       }
       emitter.emit(value);
     }
@@ -85,6 +89,12 @@ public class Kafka08ConsumingApp extends KafkaConsumingApp {
         configurer.setBrokers(runtimeArgs.get("kafka.brokers"));
       }
       setupTopicPartitions(configurer, runtimeArgs);
+      if (runtimeArgs.containsKey("batch.size")) {
+        configurer.setProcessBatchSize(Integer.parseInt(runtimeArgs.get("batch.size")));
+      }
+      if (runtimeArgs.containsKey("max.process.millis")) {
+        configurer.setMaxProcessTime(Integer.parseInt(runtimeArgs.get("max.process.millis")));
+      }
     }
 
     @Override

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/DefaultKafkaConfigurer.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/DefaultKafkaConfigurer.java
@@ -21,6 +21,7 @@ import org.apache.twill.kafka.client.TopicPartition;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default implementation of {@link KafkaConfigurer}.
@@ -30,6 +31,9 @@ final class DefaultKafkaConfigurer implements KafkaConfigurer {
   private String zookeeper;
   private String brokers;
   private final Map<TopicPartition, Integer> topicPartitions = Maps.newHashMap();
+
+  private int batchSize = 100000;
+  private long maxProcessTimeMillis = TimeUnit.SECONDS.toMillis(10);
 
   @Override
   public void setZooKeeper(String zookeeper) {
@@ -51,6 +55,16 @@ final class DefaultKafkaConfigurer implements KafkaConfigurer {
     topicPartitions.put(new TopicPartition(topic, partition), fetchSize);
   }
 
+  @Override
+  public void setProcessBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public void setMaxProcessTime(long maxProcessTimeMillis) {
+    this.maxProcessTimeMillis = maxProcessTimeMillis;
+  }
+
   String getBrokers() {
     return brokers;
   }
@@ -61,5 +75,13 @@ final class DefaultKafkaConfigurer implements KafkaConfigurer {
 
   Map<TopicPartition, Integer> getTopicPartitions() {
     return Collections.unmodifiableMap(topicPartitions);
+  }
+
+  int getBatchSize() {
+    return batchSize;
+  }
+
+  long getMaxProcessTimeMillis() {
+    return maxProcessTimeMillis;
   }
 }

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/DefaultKafkaConfigurer.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/DefaultKafkaConfigurer.java
@@ -32,7 +32,7 @@ final class DefaultKafkaConfigurer implements KafkaConfigurer {
   private String brokers;
   private final Map<TopicPartition, Integer> topicPartitions = Maps.newHashMap();
 
-  private int batchSize = 100000;
+  private int batchSize = 1000;
   private long maxProcessTimeMillis = TimeUnit.SECONDS.toMillis(10);
 
   @Override

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/KafkaConsumerConfigurer.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/KafkaConsumerConfigurer.java
@@ -24,7 +24,7 @@ public interface KafkaConsumerConfigurer {
   /**
    * Default message fetch size in bytes when making Kafka fetch request.
    */
-  static final int DEFAULT_FETCH_SIZE = 1048576;  // 1M
+  int DEFAULT_FETCH_SIZE = 1048576;  // 1M
 
   /**
    * Adds a topic partition to consume message from. Same as calling
@@ -37,11 +37,26 @@ public interface KafkaConsumerConfigurer {
   void addTopicPartition(String topic, int partition);
 
   /**
-   * Adds a topic partition to consumer message from, using the given fetch size for each fetch request.
+   * Adds a topic partition to consume message from, using the given fetch size for each fetch request.
    *
    * @param topic name of the Kafka topic
    * @param partition partition number
    * @param fetchSize maximum number of bytes to fetch per request
    */
   void addTopicPartition(String topic, int partition, int fetchSize);
+
+  /**
+   * Sets an upper bound on the number of messages that will be processed before the offsets are committed.
+   *
+   * @param batchSize number of messages to process
+   */
+  void setProcessBatchSize(int batchSize);
+
+  /**
+   * Sets an approximation on the upper bound of time that will be spent processing messages before the offsets
+   * are committed.
+   *
+   * @param maxProcessTimeMillis amount of time that can be spent processing events, in milliseconds
+   */
+  void setMaxProcessTime(long maxProcessTimeMillis);
 }

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/KafkaConsumerFlowlet.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/KafkaConsumerFlowlet.java
@@ -464,7 +464,9 @@ public abstract class KafkaConsumerFlowlet<KEY, PAYLOAD, OFFSET> extends Abstrac
   private void updateMaxProcessLimits() {
     // split the limits across the different consumerInfos. Otherwise, the first few consumerInfos may
     // starve the later consumerInfos
-    maxProcessEvents = kafkaConfigurer.getBatchSize() / consumerInfos.values().size();
     maxProcessMillis = kafkaConfigurer.getMaxProcessTimeMillis() / consumerInfos.values().size();
+    // minimum batch size of 1 (for instance, user might configure batch size of 10, and there may be 8 topic
+    // partitions). This would otherwise result in a batch size of 0
+    maxProcessEvents = Math.max(1, kafkaConfigurer.getBatchSize() / consumerInfos.values().size());
   }
 }

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/KafkaConsumerFlowlet.java
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/main/java/co/cask/cdap/kafka/flow/KafkaConsumerFlowlet.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.flow.flowlet.InputContext;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -74,6 +75,10 @@ public abstract class KafkaConsumerFlowlet<KEY, PAYLOAD, OFFSET> extends Abstrac
   private Map<TopicPartition, KafkaConsumerInfo<OFFSET>> changedConsumerInfos;
   private int instances;
 
+  private DefaultKafkaConfigurer kafkaConfigurer;
+  private int maxProcessEvents;
+  private long maxProcessMillis;
+
   /**
    * Initialize this {@link Flowlet}. Child class must call this method explicitly when overriding it.
    */
@@ -107,6 +112,9 @@ public abstract class KafkaConsumerFlowlet<KEY, PAYLOAD, OFFSET> extends Abstrac
     kafkaConfig = new KafkaConfig(kafkaConfigurer.getZookeeper(), kafkaConfigurer.getBrokers());
     consumerInfos = createConsumerInfos(kafkaConfigurer.getTopicPartitions());
     changedConsumerInfos = consumerInfos;
+
+    this.kafkaConfigurer = kafkaConfigurer;
+    updateMaxProcessLimits();
   }
 
   /**
@@ -138,8 +146,10 @@ public abstract class KafkaConsumerFlowlet<KEY, PAYLOAD, OFFSET> extends Abstrac
     boolean infosUpdated = false;
     // Poll for messages from Kafka
     for (KafkaConsumerInfo<OFFSET> info : consumerInfos.values()) {
+      Stopwatch stopwatch = new Stopwatch().start();
+      int numProcessed = 0;
       Iterator<KafkaMessage<OFFSET>> iterator = readMessages(info);
-      while (iterator.hasNext()) {
+      while (iterator.hasNext() && numProcessed++ < maxProcessEvents && stopwatch.elapsedMillis() < maxProcessMillis) {
         KafkaMessage<OFFSET> message = iterator.next();
         processMessage(message);
 
@@ -447,5 +457,14 @@ public abstract class KafkaConsumerFlowlet<KEY, PAYLOAD, OFFSET> extends Abstrac
                                                   getBeginOffset(entry.getKey())));
       }
     }
+    updateMaxProcessLimits();
+  }
+
+  // we need to update the limits whenever the number of consumerInfos may have changed
+  private void updateMaxProcessLimits() {
+    // split the limits across the different consumerInfos. Otherwise, the first few consumerInfos may
+    // starve the later consumerInfos
+    maxProcessEvents = kafkaConfigurer.getBatchSize() / consumerInfos.values().size();
+    maxProcessMillis = kafkaConfigurer.getMaxProcessTimeMillis() / consumerInfos.values().size();
   }
 }

--- a/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/test/resources/logback-test.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/cdap-kafka-flow-core/src/test/resources/logback-test.xml
@@ -32,6 +32,7 @@
   <logger name="org.apache.hive" level="WARN"/>
   <logger name="org.quartz.core" level="WARN"/>
 
+  <logger name="co.cask.cdap" level="INFO" />
   <logger name="co.cask.cdap.kafka.flow" level="DEBUG" />
 
   <root level="INFO">

--- a/cdap-kafka-pack/cdap-kafka-flow/pom.xml
+++ b/cdap-kafka-pack/cdap-kafka-flow/pom.xml
@@ -86,7 +86,7 @@
   </modules>
 
   <properties>
-    <cdap.version>3.5.0-SNAPSHOT</cdap.version>
+    <cdap.version>3.5.3</cdap.version>
     <guava.version>13.0.1</guava.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
CDAP-7731 Add limits on number of messages and duration to process per flowlet tick method.